### PR TITLE
Fix broken url to "Better Bloom Filter" paper

### DIFF
--- a/src/main/java/org/acaro/sketches/utils/BloomFilter.java
+++ b/src/main/java/org/acaro/sketches/utils/BloomFilter.java
@@ -135,7 +135,7 @@ public class BloomFilter {
 
 	// Murmur is faster than an SHA-based approach and provides as-good collision
 	// resistance.  The combinatorial generation approach described in
-	// http://www.eecs.harvard.edu/~kirsch/pubs/bbbf/esa06.pdf
+	// https://www.eecs.harvard.edu/~michaelm/postscripts/tr-02-05.pdf
 	// does prove to work in actual tests, and is obviously faster
 	// than performing further iterations of murmur.
 	private static long[] getHashBuckets(byte[] b, int hashCount, long max) {


### PR DESCRIPTION
I noticed that this link was broken so I replaced it with a link to a copy provided by the other author